### PR TITLE
Update TextareaDecorator.css

### DIFF
--- a/lib/TextareaDecorator.css
+++ b/lib/TextareaDecorator.css
@@ -33,6 +33,7 @@
 
 .ldt pre {
 	-moz-padding-start: 1px;
+	margin: 0;
 }
 
 .ldt label {

--- a/lib/TextareaDecorator.css
+++ b/lib/TextareaDecorator.css
@@ -34,6 +34,7 @@
 .ldt pre {
 	-moz-padding-start: 1px;
 	margin: 0;
+	overflow: initial;
 }
 
 .ldt label {


### PR DESCRIPTION
If you try to hook up the default setting, you’ll get this: http://jsfiddle.net/7zob0zbp/
As you see, `pre` needs to be set `margin:0`.