### PR TITLE
Fixing caret issue

### DIFF
--- a/lib/TextareaDecorator.css
+++ b/lib/TextareaDecorator.css
@@ -18,7 +18,7 @@
 
 .ldt textarea {
 	/* hide the text but show the text caret */
-	color: transparent !important;
+	color: rgba(255,255,255,0.02);
 	caret-color: #000;
 }
 
@@ -32,6 +32,10 @@
 .ldt pre {
 	margin: 0;
 	overflow: initial;
+	position: relative;
+	z-index: 2;
+	background: transparent;
+	pointer-events: none;
 }
 
 .ldt label {

--- a/lib/TextareaDecorator.css
+++ b/lib/TextareaDecorator.css
@@ -18,7 +18,9 @@
 
 .ldt textarea {
 	/* hide the text but show the text caret */
-	color: rgba(255,255,255,0.02);
+	color: transparent;
+	/* Firefox caret position is slow to update when color is transparent */
+	color: rgba(0, 0, 0, 0.004);
 	caret-color: #000;
 }
 

--- a/lib/TextareaDecorator.css
+++ b/lib/TextareaDecorator.css
@@ -32,10 +32,6 @@
 .ldt pre {
 	margin: 0;
 	overflow: initial;
-	position: relative;
-	z-index: 2;
-	background: transparent;
-	pointer-events: none;
 }
 
 .ldt label {


### PR DESCRIPTION
There was a problem with the caret (Tested in firefox dev edition)

Cause of the textarea transparent text color, when I was clicking at an other place of the textarea, the caret needed some time to be moved, it has to disappear from it's old location and next it was going to appear at the good location.

If we put the textarea color in white, with very very low opacity, it works pretty well and we can't see the difference !