### PR TITLE
Disable text-size-adjust

### DIFF
--- a/lib/TextareaDecorator.css
+++ b/lib/TextareaDecorator.css
@@ -29,6 +29,8 @@
 .ldt {
 	overflow: auto;
 	position: relative;
+	text-size-adjust: none;
+	-webkit-text-size-adjust: none;
 }
 
 .ldt pre {


### PR DESCRIPTION
This caused the output layer, but not input layer, to be scaled up on iOS Safari
Fixes #22