### PR TITLE
Inert attribute usage

### DIFF
--- a/lib/TextareaDecorator.js
+++ b/lib/TextareaDecorator.js
@@ -11,6 +11,7 @@ function TextareaDecorator( textarea, parser ){
 	// construct editor DOM
 	var parent = document.createElement("div");
 	var output = document.createElement("pre");
+	output.inert = true; // prevents Ctrl+F search
 	parent.appendChild(output);
 	var label = document.createElement("label");
 	parent.appendChild(label);


### PR DESCRIPTION
To prevent search on the output element, so only original textarea content will be found

Works in Chrome 124 and in Firefox